### PR TITLE
feat: カレンダー表示の最適化 - 横幅拡大と時間表示領域の調整

### DIFF
--- a/app/src/main/java/com/sbm/application/presentation/screen/main/CalendarScreen.kt
+++ b/app/src/main/java/com/sbm/application/presentation/screen/main/CalendarScreen.kt
@@ -113,7 +113,7 @@ fun CalendarScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 20.dp, vertical = 16.dp) // 緑・青テーマに合わせてゆったりと
+                .padding(horizontal = 8.dp, vertical = 16.dp) // 緑・青テーマに合わせてゆったりと
         ) {
             // 表示切替タブ
             Row(
@@ -505,7 +505,7 @@ fun WeeklyCalendarView(
         Row(modifier = Modifier.fillMaxWidth()) {
             Box(
                 modifier = Modifier
-                    .width(60.dp)
+                    .width(40.dp)
                     .height(48.dp),
                 contentAlignment = Alignment.Center
             ) {
@@ -547,7 +547,7 @@ fun WeeklyCalendarView(
         ) {
             Box(
                 modifier = Modifier
-                    .width(60.dp)
+                    .width(40.dp)
                     .height(48.dp),
                 contentAlignment = Alignment.Center
             ) {
@@ -611,7 +611,7 @@ fun WeeklyCalendarView(
             // 時間軸ラベル列
             Column(
                 modifier = Modifier
-                    .width(60.dp)
+                    .width(40.dp)
                     .fillMaxHeight()
             ) {
                 for (hour in startHour until endHour) {
@@ -640,7 +640,7 @@ fun WeeklyCalendarView(
             Row(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(start = 60.dp)
+                    .padding(start = 40.dp)
             ) {
                 weekDays.forEach { date ->
                     val dateString = date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))


### PR DESCRIPTION
## Summary
- 時間表示部分の横幅を60dpから40dpに縮小し、カレンダー本体の表示領域を拡大
- カレンダー全体の水平paddingを20dpから8dpに縮小し、デバイス横幅をより有効活用
- 週表示カレンダーの視認性とユーザビリティを向上

## 変更内容
- `WeeklyCalendarView`の時間表示領域: 60dp → 40dp
- `CalendarScreen`の水平padding: 20dp → 8dp  
- カレンダー本体のstart padding: 60dp → 40dp

## Test plan
- [ ] アプリをビルドして週表示カレンダーを確認
- [ ] 時間表示が適切に見えることを確認
- [ ] カレンダー本体がより広く表示されることを確認
- [ ] 様々なデバイスサイズでレイアウトが適切に表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)