### PR TITLE
期間選択とイベント登録の日付ピッカーUI改善

### DIFF
--- a/app/src/main/java/com/sbm/application/presentation/screen/main/AnalysisScreen.kt
+++ b/app/src/main/java/com/sbm/application/presentation/screen/main/AnalysisScreen.kt
@@ -8,12 +8,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material3.*
+import androidx.compose.material3.Divider
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.sbm.application.presentation.theme.CuteDesignSystem
 import java.time.Instant
@@ -379,21 +381,88 @@ fun CustomDateRangePickerDialog(
         }.getOrNull()
     )
     
-    Dialog(onDismissRequest = onDismiss) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
         Surface(
             modifier = Modifier
-                .fillMaxWidth()
+                .fillMaxWidth(0.95f)  // 95%の幅で余裕を持たせる
                 .fillMaxHeight(0.9f),
             shape = RoundedCornerShape(16.dp),
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 6.dp
         ) {
             Column {
+                // カスタムヘッダー
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = "期間を選択",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        
+                        Spacer(modifier = Modifier.height(8.dp))
+                        
+                        // 選択された期間の表示
+                        val startMillis = dateRangePickerState.selectedStartDateMillis
+                        val endMillis = dateRangePickerState.selectedEndDateMillis
+                        if (startMillis != null && endMillis != null) {
+                            val displayDateFormatter = DateTimeFormatter.ofPattern("yyyy年M月d日")
+                            val start = Instant.ofEpochMilli(startMillis)
+                                .atZone(ZoneId.systemDefault())
+                                .toLocalDate()
+                                .format(displayDateFormatter)
+                            val end = Instant.ofEpochMilli(endMillis)
+                                .atZone(ZoneId.systemDefault())
+                                .toLocalDate()
+                                .format(displayDateFormatter)
+                            
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.Center,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = start,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                                Text(
+                                    text = " 〜 ",
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                Text(
+                                    text = end,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    }
+                }
+                
+                Divider(
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.outlineVariant
+                )
+                
                 // DateRangePicker
                 DateRangePicker(
                     state = dateRangePickerState,
                     modifier = Modifier.weight(1f),
-                    showModeToggle = false
+                    showModeToggle = false,
+                    title = null,  // デフォルトタイトルを非表示
+                    headline = null  // デフォルトヘッドラインも非表示
                 )
                 
                 // Action buttons


### PR DESCRIPTION
## Summary
- 期間選択ダイアログの幅調整とUIレイアウト改善 
- 新規イベント画面の日付入力をカレンダーピッカーに変更
- 気分トレンドグラフの期間表示バグ修正

## Changes
- 期間選択ダイアログの幅を95%に調整し、カレンダーの右端圧縮問題を解決
- カスタムヘッダー追加で選択期間を「2025年8月1日〜2025年8月29日」形式で見やすく表示  
- デフォルトヘッダー/ヘッドラインを非表示にしてカスタムUIに統一
- 新規イベント画面の日付入力をテキストからカレンダーピッカーに変更
- DatePickerDialogコンポーネント追加でアプリ全体の操作性を統一
- 変数名シャドウイング問題を解決（displayDateFormatterに分離）
- 気分トレンドグラフの期間表示バグ修正（takeLast(30)制限除去）

## Test Plan
- [x] 期間選択ダイアログでカレンダーの右端が正しく表示されること
- [x] カスタムヘッダーで選択期間が適切に表示されること  
- [x] 新規イベント作成時に日付ピッカーが正常に動作すること
- [x] 1週間/1ヶ月/3ヶ月/カスタム期間がそれぞれ正しく表示されること
- [x] ビルドが正常に完了すること

🤖 Generated with [Claude Code](https://claude.ai/code)