### PR TITLE
feat: ブルートフォース攻撃対策とエラーハンドリング強化

### DIFF
--- a/app/src/main/java/com/sbm/application/data/remote/dto/AuthDto.kt
+++ b/app/src/main/java/com/sbm/application/data/remote/dto/AuthDto.kt
@@ -54,4 +54,17 @@ object AuthDto {
         @SerializedName("refreshToken")
         val refreshToken: String?
     )
+    
+    data class ErrorResponse(
+        @SerializedName("error")
+        val error: String?,
+        @SerializedName("message")
+        val message: String?,
+        @SerializedName("errorType")
+        val errorType: String?, // ACCOUNT_LOCKED, BAD_CREDENTIALS, etc.
+        @SerializedName("lockoutTimeRemaining")
+        val lockoutTimeRemaining: Long? = null, // ロックアウト残り時間（秒）
+        @SerializedName("remainingAttempts")
+        val remainingAttempts: Int? = null // 残り試行可能回数
+    )
 }

--- a/app/src/main/java/com/sbm/application/domain/exception/AuthenticationExceptions.kt
+++ b/app/src/main/java/com/sbm/application/domain/exception/AuthenticationExceptions.kt
@@ -1,0 +1,15 @@
+package com.sbm.application.domain.exception
+
+sealed class AuthenticationException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+class AccountLockedException(
+    message: String,
+    val lockoutTimeRemaining: Long? = null
+) : AuthenticationException(message)
+
+class BadCredentialsException(
+    message: String,
+    val remainingAttempts: Int? = null
+) : AuthenticationException(message)
+
+class AuthenticationFailedException(message: String) : AuthenticationException(message)

--- a/app/src/main/java/com/sbm/application/presentation/screen/auth/LoginScreen.kt
+++ b/app/src/main/java/com/sbm/application/presentation/screen/auth/LoginScreen.kt
@@ -2,11 +2,13 @@ package com.sbm.application.presentation.screen.auth
 
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
+
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -31,6 +33,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.sbm.application.config.ApiConfig
 import com.sbm.application.R
 import com.sbm.application.presentation.viewmodel.AuthViewModel
+import com.sbm.application.presentation.viewmodel.AuthErrorType
 import com.sbm.application.presentation.theme.CuteDesignSystem
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -55,7 +58,7 @@ fun LoginScreen(
                 // ナビゲーション失敗時のログ
                 try {
                     if (com.sbm.application.BuildConfig.DEBUG) {
-                        Log.e("LoginScreen", "Navigation failed", e)
+
                     }
                 } catch (ex: Exception) {
                     // リリースビルドではログを出力しない
@@ -80,10 +83,13 @@ fun LoginScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(CuteDesignSystem.Spacing.XXL),
+                .padding(CuteDesignSystem.Spacing.XXL)
+                .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.Top
         ) {
+            Spacer(modifier = Modifier.height(CuteDesignSystem.Spacing.XXL)) // 上部余白
+            
             // アプリタイトル部分
             Card(
                 modifier = Modifier
@@ -136,6 +142,30 @@ fun LoginScreen(
                         modifier = Modifier.padding(top = CuteDesignSystem.Spacing.XS)
                     )
                 }
+            }
+            
+            // エラー表示（タイトルカードとログインフォームの間）
+            uiState.error?.let { error ->
+                when (uiState.errorType) {
+                    AuthErrorType.ACCOUNT_LOCKED -> {
+                        AccountLockedErrorCard(
+                            error = error,
+                            lockoutTimeRemaining = uiState.lockoutTimeRemaining
+                        )
+                    }
+                    AuthErrorType.BAD_CREDENTIALS -> {
+                        BadCredentialsErrorCard(
+                            error = error,
+                            remainingAttempts = uiState.remainingAttempts
+                        )
+                    }
+                    AuthErrorType.AUTHENTICATION_FAILED,
+                    AuthErrorType.GENERAL_ERROR,
+                    null -> {
+                        GeneralErrorCard(error = error)
+                    }
+                }
+                Spacer(modifier = Modifier.height(CuteDesignSystem.Spacing.LG))
             }
             
             // ログインフォームカード
@@ -226,7 +256,7 @@ fun LoginScreen(
                             // ログインボタンクリック時のログ
                             try {
                                 if (com.sbm.application.BuildConfig.DEBUG) {
-                                    Log.d("LoginScreen", "Login button clicked")
+
                                 }
                             } catch (e: Exception) {
                                 // リリースビルドではログを出力しない
@@ -411,40 +441,158 @@ fun LoginScreen(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun AccountLockedErrorCard(
+    error: String,
+    lockoutTimeRemaining: Long?
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = CuteDesignSystem.Shapes.Medium,
+        colors = CardDefaults.cardColors(
+            containerColor = CuteDesignSystem.Colors.Error.copy(alpha = 0.1f)
+        ),
+        border = androidx.compose.foundation.BorderStroke(
+            1.dp,
+            CuteDesignSystem.Colors.Error.copy(alpha = 0.3f)
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(CuteDesignSystem.Spacing.LG)
+        ) {
+
             
-            // エラー表示
-            uiState.error?.let { error ->
-                Spacer(modifier = Modifier.height(CuteDesignSystem.Spacing.LG))
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = CuteDesignSystem.Shapes.Medium,
-                    colors = CardDefaults.cardColors(
-                        containerColor = CuteDesignSystem.Colors.Error.copy(alpha = 0.1f)
-                    ),
-                    border = androidx.compose.foundation.BorderStroke(
-                        1.dp,
-                        CuteDesignSystem.Colors.Error.copy(alpha = 0.3f)
+            Text(
+                text = error,
+                color = CuteDesignSystem.Colors.Error,
+                style = MaterialTheme.typography.bodyMedium,
+                lineHeight = 20.sp
+            )
+            
+            lockoutTimeRemaining?.let { timeRemaining ->
+                if (timeRemaining > 0) {
+                    Spacer(modifier = Modifier.height(CuteDesignSystem.Spacing.SM))
+                    
+                    val minutes = (timeRemaining / 60).toInt()
+                    val seconds = (timeRemaining % 60).toInt()
+                    
+                    LinearProgressIndicator(
+                        progress = 1.0f - (timeRemaining / (15 * 60f)), // 15分でロック解除
+                        modifier = Modifier.fillMaxWidth(),
+                        color = CuteDesignSystem.Colors.Error,
+                        trackColor = CuteDesignSystem.Colors.Error.copy(alpha = 0.2f)
                     )
-                ) {
+                    
+                    Spacer(modifier = Modifier.height(CuteDesignSystem.Spacing.XS))
+                    
+                    Text(
+                        text = "残り時間: ${minutes}分${seconds}秒",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = CuteDesignSystem.Colors.OnSurfaceVariant,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BadCredentialsErrorCard(
+    error: String,
+    remainingAttempts: Int?
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = CuteDesignSystem.Shapes.Medium,
+        colors = CardDefaults.cardColors(
+            containerColor = CuteDesignSystem.Colors.Error.copy(alpha = 0.1f)
+        ),
+        border = androidx.compose.foundation.BorderStroke(
+            1.dp,
+            CuteDesignSystem.Colors.Error.copy(alpha = 0.3f)
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(CuteDesignSystem.Spacing.LG)
+        ) {
+
+            
+            Text(
+                text = error,
+                color = CuteDesignSystem.Colors.Error,
+                style = MaterialTheme.typography.bodyMedium,
+                lineHeight = 20.sp
+            )
+            
+            remainingAttempts?.let { attempts ->
+                if (attempts > 0) {
+                    Spacer(modifier = Modifier.height(CuteDesignSystem.Spacing.SM))
+                    
+                    // 残り試行回数のインジケーター
                     Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(CuteDesignSystem.Spacing.LG),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
+                        repeat(5) { index ->
+                            Box(
+                                modifier = Modifier
+                                    .size(12.dp)
+                                    .background(
+                                        color = if (index < attempts) Color(0xFF4CAF50) else Color(0xFFE0E0E0),
+                                        shape = androidx.compose.foundation.shape.CircleShape
+                                    )
+                            )
+                            if (index < 4) {
+                                Spacer(modifier = Modifier.width(4.dp))
+                            }
+                        }
+                        
+                        Spacer(modifier = Modifier.width(CuteDesignSystem.Spacing.SM))
+                        
                         Text(
-                            text = "⚠️",
-                            fontSize = 20.sp,
-                            modifier = Modifier.padding(end = CuteDesignSystem.Spacing.SM)
-                        )
-                        Text(
-                            text = error,
-                            color = CuteDesignSystem.Colors.Error,
-                            style = MaterialTheme.typography.bodyMedium
+                            text = "残り${attempts}回",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = CuteDesignSystem.Colors.OnSurfaceVariant,
+                            fontWeight = FontWeight.Medium
                         )
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun GeneralErrorCard(error: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = CuteDesignSystem.Shapes.Medium,
+        colors = CardDefaults.cardColors(
+            containerColor = CuteDesignSystem.Colors.Error.copy(alpha = 0.1f)
+        ),
+        border = androidx.compose.foundation.BorderStroke(
+            1.dp,
+            CuteDesignSystem.Colors.Error.copy(alpha = 0.3f)
+        )
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(CuteDesignSystem.Spacing.LG)
+        ) {
+            Text(
+                text = error,
+                color = CuteDesignSystem.Colors.Error,
+                style = MaterialTheme.typography.bodyMedium
+            )
         }
     }
 }


### PR DESCRIPTION
## 概要
API PR #64とUI PR #100の仕様に基づいて、Android ネイティブアプリにブルートフォース攻撃対策とエラーハンドリング強化を実装しました。

## 主な変更内容

### 🔒 セキュリティ強化
- 5回のログイン失敗後15分間のアカウントロック機能
- HTTPステータスコード別の適切なエラー処理（401: 認証失敗、423: アカウントロック）
- APIレスポンスからの安全なJSON解析とエラーメッセージ抽出

### 🎨 UI/UX改善  
- エラータイプ別の専用エラーカード実装
  - アカウントロック：残り時間表示＋進捗バー
  - 認証失敗：残りログイン試行回数の視覚的インジケーター
  - 一般エラー：シンプルなエラー表示
- エラー表示位置をタイトルとログインフォーム間に配置
- スクロール対応とレスポンシブデザイン

### 🛠 アーキテクチャ改善
- 型安全な認証例外クラス（`AccountLockedException`, `BadCredentialsException`, `AuthenticationFailedException`）
- `AuthViewModel`での詳細なエラー状態管理
- ネットワークエラー（タイムアウト、接続性）の適切な処理

### 🧹 コード品質向上
- デバッグログとコメントのクリーンアップ
- 不要なimportの削除
- セキュリティを考慮した実装（機密情報の非表示）

## テスト計画
- [ ] 正常ログイン動作の確認
- [ ] 5回連続ログイン失敗時のアカウントロック動作
- [ ] エラーメッセージの適切な表示確認
- [ ] ネットワーク切断時のエラー処理
- [ ] レスポンシブデザインの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)