### PR TITLE
feat: リフレッシュトークンによるログイン状態維持機能を実装 (v1.0.4)

### DIFF
--- a/app/src/main/java/com/sbm/application/data/remote/ApiService.kt
+++ b/app/src/main/java/com/sbm/application/data/remote/ApiService.kt
@@ -23,6 +23,9 @@ interface ApiService {
     @POST("auth/refresh")
     suspend fun refreshToken(@Body refreshRequest: AuthDto.RefreshTokenRequest): Response<AuthDto.RefreshTokenResponse>
     
+    @POST("auth/logout")
+    suspend fun logout(@Body logoutRequest: AuthDto.LogoutRequest): Response<ResponseBody>
+    
     @FormUrlEncoded
     @POST("auth/oauth2/session")
     suspend fun getOAuth2Session(

--- a/app/src/main/java/com/sbm/application/data/remote/AuthInterceptor.kt
+++ b/app/src/main/java/com/sbm/application/data/remote/AuthInterceptor.kt
@@ -1,8 +1,8 @@
 package com.sbm.application.data.remote
 
 import android.content.Context
-import android.util.Log
 import com.sbm.application.data.security.SecureTokenManager
+import com.sbm.application.data.security.SecureLogger
 import dagger.hilt.android.qualifiers.ApplicationContext
 import okhttp3.Interceptor
 import okhttp3.Response
@@ -11,7 +11,7 @@ import javax.inject.Inject
 class AuthInterceptor @Inject constructor(
     @ApplicationContext private val context: Context
 ) : Interceptor {
-    
+
     companion object {
         // 認証エラー時のコールバック
         var onAuthError: ((Int, String) -> Unit)? = null
@@ -19,33 +19,33 @@ class AuthInterceptor @Inject constructor(
         var refreshTokenCallback: (suspend () -> Boolean)? = null
         private const val TAG = "AuthInterceptor"
     }
-    
+
     // セキュアなトークン管理
     private val tokenManager: SecureTokenManager by lazy {
         SecureTokenManager(context)
     }
-    
+
     // 同時リフレッシュを防ぐための排他制御
     @Volatile
     private var isRefreshing = false
-    
+
     // リフレッシュ頻度制限
     @Volatile
     private var lastRefreshTime = 0L
     @Volatile
     private var refreshCount = 0
-    
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
-        
+
         // 認証が不要なエンドポイントをスキップ
         val url = originalRequest.url.toString()
-        if (url.contains("/auth/login") || 
-            url.contains("/auth/register") || 
+        if (url.contains("/auth/login") ||
+            url.contains("/auth/register") ||
             url.contains("/auth/refresh")) {
             return chain.proceed(originalRequest)
         }
-        
+
         return try {
             // アクセストークン取得
             val accessToken = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
@@ -53,7 +53,7 @@ class AuthInterceptor @Inject constructor(
             } else {
                 null
             }
-            
+
             // 最初のリクエスト実行
             var response = if (!accessToken.isNullOrEmpty()) {
                 val authenticatedRequest = originalRequest.newBuilder()
@@ -63,20 +63,22 @@ class AuthInterceptor @Inject constructor(
             } else {
                 chain.proceed(originalRequest)
             }
-            
+
             // 401エラーの場合、リフレッシュを試行
             if (response.code == 401 && !isRefreshing && refreshTokenCallback != null && canRefresh()) {
                 response.close()
-                
+
                 synchronized(this) {
                     if (!isRefreshing) {
                         isRefreshing = true
-                        
+
                         try {
+                            // TODO: runBlockingの使用はOkHttpスレッドプールをブロックするため非推奨
+                            // 将来的にAuthenticatorへの移行を検討 (Issue #XX)
                             val refreshResult = kotlinx.coroutines.runBlocking {
                                 refreshTokenCallback?.invoke() ?: false
                             }
-                            
+
                             if (refreshResult) {
                                 recordRefresh()
                                 // リフレッシュ成功：新しいトークンで再試行
@@ -85,24 +87,24 @@ class AuthInterceptor @Inject constructor(
                                 } else {
                                     null
                                 }
-                                
+
                                 if (!newAccessToken.isNullOrEmpty()) {
                                     val retryRequest = originalRequest.newBuilder()
                                         .header("Authorization", "Bearer $newAccessToken")
                                         .build()
                                     response = chain.proceed(retryRequest)
-                                    Log.d(TAG, "トークンリフレッシュ後の再試行成功")
+                                    SecureLogger.debug(TAG, "トークンリフレッシュ後の再試行成功")
                                 } else {
-                                    Log.w(TAG, "リフレッシュ後のトークン取得に失敗")
+                                    SecureLogger.warn(TAG, "リフレッシュ後のトークン取得に失敗")
                                     onAuthError?.invoke(401, "トークンリフレッシュ後のトークン取得に失敗")
                                 }
                             } else {
                                 // リフレッシュ失敗：ログイン画面へ
-                                Log.w(TAG, "リフレッシュトークンが無効")
+                                SecureLogger.warn(TAG, "リフレッシュトークンが無効")
                                 onAuthError?.invoke(401, "リフレッシュトークンが無効です")
                             }
                         } catch (e: Exception) {
-                            Log.e(TAG, "リフレッシュ処理中にエラー", e)
+                            SecureLogger.error(TAG, "リフレッシュ処理中にエラー", e)
                             onAuthError?.invoke(401, "認証エラー")
                         } finally {
                             isRefreshing = false
@@ -111,52 +113,52 @@ class AuthInterceptor @Inject constructor(
                 }
             } else if (response.code == 401) {
                 // リフレッシュコールバックが設定されていない場合
-                Log.w(TAG, "401エラーですが、リフレッシュコールバックが未設定")
+                SecureLogger.warn(TAG, "401エラーですが、リフレッシュコールバックが未設定")
                 onAuthError?.invoke(401, "認証が必要です")
             } else if (response.code == 403) {
                 // 権限エラー
                 onAuthError?.invoke(403, "アクセス権限がありません")
             }
-            
+
             response
         } catch (securityException: SecurityException) {
-            Log.e(TAG, "認証システムエラー", securityException)
-            onAuthError?.invoke(500, "認証システムエラー: ${securityException.message}")
+            SecureLogger.error(TAG, "認証システムエラー", securityException)
+            onAuthError?.invoke(500, "認証システムエラー")
             chain.proceed(originalRequest)
         } catch (e: Exception) {
-            Log.e(TAG, "インターセプターエラー", e)
+            SecureLogger.error(TAG, "インターセプターエラー", e)
             chain.proceed(originalRequest)
         }
     }
-    
+
     /**
      * リフレッシュ頻度制限チェック
      * @return リフレッシュ可能な場合true
      */
     private fun canRefresh(): Boolean {
         val now = System.currentTimeMillis()
-        
+
         // 1分間経過したらカウントリセット
         if (now - lastRefreshTime > 60000) {
             refreshCount = 0
             lastRefreshTime = now
         }
-        
+
         // 1分間に3回まで
         val canRefresh = refreshCount < 3
-        
+
         if (!canRefresh) {
-            Log.w(TAG, "リフレッシュ頻度制限に達しました (${refreshCount}/3)")
+            SecureLogger.warn(TAG, "リフレッシュ頻度制限に達しました ($refreshCount/3)")
         }
-        
+
         return canRefresh
     }
-    
+
     /**
      * リフレッシュ実行を記録
      */
     private fun recordRefresh() {
         refreshCount++
-        Log.d(TAG, "リフレッシュ実行記録: ${refreshCount}/3")
+        SecureLogger.debug(TAG, "リフレッシュ実行記録: $refreshCount/3")
     }
 }

--- a/app/src/main/java/com/sbm/application/data/remote/dto/AuthDto.kt
+++ b/app/src/main/java/com/sbm/application/data/remote/dto/AuthDto.kt
@@ -55,6 +55,11 @@ object AuthDto {
         val refreshToken: String?
     )
     
+    data class LogoutRequest(
+        @SerializedName("refreshToken")
+        val refreshToken: String
+    )
+    
     data class ErrorResponse(
         @SerializedName("error")
         val error: String?,

--- a/app/src/main/java/com/sbm/application/data/remote/dto/LoginResponse.kt
+++ b/app/src/main/java/com/sbm/application/data/remote/dto/LoginResponse.kt
@@ -6,5 +6,7 @@ data class LoginResponse(
     @SerializedName("token")
     val token: String,
     @SerializedName("userId")
-    val userId: String
+    val userId: String,
+    @SerializedName("refreshToken")
+    val refreshToken: String? = null
 )

--- a/app/src/main/java/com/sbm/application/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/sbm/application/data/repository/AuthRepositoryImpl.kt
@@ -136,7 +136,7 @@ class AuthRepositoryImpl @Inject constructor(
                         apiService.logout(AuthDto.LogoutRequest(refreshToken))
                     } catch (e: Exception) {
                         // ネットワークエラーは無視してローカルクリーンアップを続行
-                        com.sbm.application.data.security.SecureLogger.debug("AuthRepository", "ログアウト通知失敗（続行）: ${e.message}")
+                        com.sbm.application.data.security.SecureLogger.debug("AuthRepository", "ログアウト通知失敗（続行）")
                     }
                 }
                 

--- a/app/src/main/java/com/sbm/application/data/security/JWTValidator.kt
+++ b/app/src/main/java/com/sbm/application/data/security/JWTValidator.kt
@@ -90,6 +90,27 @@ object JWTValidator {
             return false
         }
     }
+
+    /**
+     * トークンの有効期限が近いかチェック
+     * @param token JWTトークン
+     * @param thresholdMinutes 閾値（分）
+     * @return 有効期限まで閾値以内の場合はtrue
+     */
+    fun isTokenExpiringSoon(token: String, thresholdMinutes: Int = 2): Boolean {
+        return try {
+            val decodedJWT = JWT.decode(token)
+            val expiresAt = decodedJWT.expiresAt ?: return false
+            
+            val currentTime = Date()
+            val thresholdTime = Date(currentTime.time + thresholdMinutes * 60 * 1000)
+            
+            // 有効期限が閾値時間より前（期限が近い）
+            expiresAt.before(thresholdTime)
+        } catch (e: Exception) {
+            false
+        }
+    }
     
     /**
      * 有効な発行者かチェック

--- a/app/src/main/java/com/sbm/application/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/sbm/application/domain/repository/AuthRepository.kt
@@ -19,4 +19,5 @@ interface AuthRepository {
     suspend fun getOAuth2Session(sessionId: String): Response<LoginResponse>
     suspend fun saveToken(token: String)
     suspend fun saveUserId(userId: String)
+    suspend fun saveRefreshToken(refreshToken: String)
 }

--- a/app/src/main/java/com/sbm/application/presentation/auth/GoogleAuthViewModel.kt
+++ b/app/src/main/java/com/sbm/application/presentation/auth/GoogleAuthViewModel.kt
@@ -20,9 +20,20 @@ class GoogleAuthViewModel @Inject constructor(
             val response = authRepository.getOAuth2Session(sessionId)
             if (response.isSuccessful) {
                 response.body()?.let { loginResponse ->
-                    // トークンを保存
+                    // アクセストークンとユーザーIDを保存
                     authRepository.saveToken(loginResponse.token)
                     authRepository.saveUserId(loginResponse.userId)
+                    
+                    // リフレッシュトークンが存在する場合は保存
+                    if (!loginResponse.refreshToken.isNullOrEmpty()) {
+                        try {
+                            authRepository.saveRefreshToken(loginResponse.refreshToken)
+                        } catch (e: Exception) {
+                            // リフレッシュトークン保存失敗時もログインは成功とする
+                            // ログは出力しない（セキュリティ上の理由）
+                        }
+                    }
+                    
                     emit(Result.Success(Unit))
                 } ?: emit(Result.Error("レスポンスが空です"))
             } else {


### PR DESCRIPTION
## 概要
リフレッシュトークンを活用してログイン状態を維持する機能を実装しました。これにより、アクセストークンが期限切れになってもリフレッシュトークンが有効な限りログイン状態を保持できるようになります。

## 主な変更内容

### 1. リフレッシュトークン自動更新機能
- `AuthRepositoryImpl.isLoggedIn()`: アクセストークンが無効な場合、リフレッシュトークンで自動更新を試行
- バックグラウンド復帰時やアプリ起動時のログイン状態保持を改善

### 2. AuthInterceptorの強化
- 401エラー時に自動的にリフレッシュトークンを使用してトークン更新
- 同時リフレッシュの防止（排他制御）
- リフレッシュ頻度制限（1分間に3回まで）

### 3. SecureTokenManagerの拡張
- `saveRefreshToken()` / `getRefreshToken()`: リフレッシュトークンの暗号化保存・取得
- `saveUserId()` / `getUserId()`: ユーザーIDの暗号化保存・取得
- Android Keystoreを使用した安全な保存

### 4. API定義の追加
- `/auth/refresh`: トークンリフレッシュエンドポイント
- `/auth/logout`: ログアウトエンドポイント（リフレッシュトークンを送信）

### 5. JWTValidatorの拡張
- `isTokenExpiringSoon()`: トークンの有効期限が近いかチェックするメソッド追加

## 修正した問題
- ❌ **修正前**: アクセストークン（3分）が期限切れになると即座にログアウト
- ✅ **修正後**: リフレッシュトークンが有効な限りログイン状態を維持

## テスト項目
- [x] ログイン後のトークン保存（アクセス・リフレッシュ・ユーザーID）
- [x] アクセストークン期限切れ時の自動リフレッシュ
- [x] バックグラウンド復帰時のログイン状態維持
- [x] API通信時の401エラーハンドリング
- [x] リフレッシュトークン期限切れ時のログアウト
- [x] ビルド成功（AAB/APK生成確認）

## 影響範囲
- 認証フロー全般
- ログイン状態の判定ロジック
- トークン管理

## バージョン
v1.0.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)